### PR TITLE
Windows 10 ISOs updated to Win10 Anniversary Edition

### DIFF
--- a/docs/windows-10-tips.adoc
+++ b/docs/windows-10-tips.adoc
@@ -13,3 +13,31 @@ understand (using Eval version).
 . Run then `netplwiz`
 . Add a user
 . Re-enable network access
+
+== Versions
+
+Replace iso_url and iso_checksum in packer config if you want to specify a
+different version of Windows.
+
+=== Anniversary Update (1607)
+
+.32 bit
+http://care.dlservice.microsoft.com/dl/download/2/5/4/254230E8-AEA5-43C5-94F6-88CE222A5846/14393.0.160715-1616.RS1_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X86FRE_EN-US.ISO
+
+.64 bit
+http://care.dlservice.microsoft.com/dl/download/2/5/4/254230E8-AEA5-43C5-94F6-88CE222A5846/14393.0.160715-1616.RS1_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO
+
+=== November Update (1511)
+
+.32 bit
+* Autounattend.xml /IMAGE/NAME: Windows 10 Enterprise Evaluation Technical Preview
+* URL: http://care.dlservice.microsoft.com/dl/download/B/B/3/BB3611B6-9781-437F-A293-AB43B85C2190/10586.0.151029-1700.TH2_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X86FRE_EN-US.ISO
+
+=== Version 1507
+
+.64 bit
+http://care.dlservice.microsoft.com/dl/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO
+
+== Understanding versioning
+
+https://en.wikipedia.org/wiki/Windows_10_version_history

--- a/malboxes/installconfig/windows10/Autounattend.xml
+++ b/malboxes/installconfig/windows10/Autounattend.xml
@@ -34,7 +34,7 @@
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/IMAGE/NAME</Key>
-                            <Value>Windows 10 Enterprise Evaluation Technical Preview</Value>
+                            <Value>Windows 10 Enterprise Evaluation</Value>
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>

--- a/malboxes/profiles/win10_32_analyst.json
+++ b/malboxes/profiles/win10_32_analyst.json
@@ -5,10 +5,10 @@
 		{% include 'snippets/builder_virtualbox_windows.json' %},
 
 		"iso_urls": [
-			"file://{{ iso_path }}/10586.0.151029-1700.TH2_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X86FRE_EN-US.ISO",
-			"http://care.dlservice.microsoft.com/dl/download/B/B/3/BB3611B6-9781-437F-A293-AB43B85C2190/10586.0.151029-1700.TH2_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X86FRE_EN-US.ISO"
+			"file://{{ iso_path }}/14393.0.160715-1616.RS1_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X86FRE_EN-US.ISO",
+			"http://care.dlservice.microsoft.com/dl/download/2/5/4/254230E8-AEA5-43C5-94F6-88CE222A5846/14393.0.160715-1616.RS1_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X86FRE_EN-US.ISO"
 		],
-		"iso_checksum": "e431a4e259a5c056a5d58b9cd0628a3c59f112f9",
+		"iso_checksum": "0b8e56772c71dc7bb73654c61e53998a997e1e4d",
 		"iso_checksum_type": "sha1",
 
 

--- a/malboxes/profiles/win10_64_analyst.json
+++ b/malboxes/profiles/win10_64_analyst.json
@@ -4,10 +4,10 @@
 		{% include 'snippets/builder_virtualbox_windows.json' %},
 
 		"iso_urls": [
-			"file://{{ iso_path }}/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
-			"http://care.dlservice.microsoft.com/dl/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO"
+			"file://{{ iso_path }}/14393.0.160715-1616.RS1_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
+			"http://care.dlservice.microsoft.com/dl/download/2/5/4/254230E8-AEA5-43C5-94F6-88CE222A5846/14393.0.160715-1616.RS1_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO"
 		],
-		"iso_checksum": "56ab095075be28a90bc0b510835280975c6bb2ce",
+		"iso_checksum": "a86ae3d664553cd0ee9a6bcd83a5dbe92e3dc41a",
 		"iso_checksum_type": "sha1",
 
 		"floppy_files": [


### PR DESCRIPTION
Worked out-of-the-box for `win10_32_analyst` profile but doesn't work with `win10_64_analyst` for a reason I don't understand yet:

```
==> virtualbox-iso: Connected to WinRM!
==> virtualbox-iso: Uploading VirtualBox version info (5.1.10)
==> virtualbox-iso: Unregistering and deleting virtual machine...
==> virtualbox-iso: Deleting output directory...
Build 'virtualbox-iso' errored: Error uploading VirtualBox version: Error uploading file to $env:TEMP\winrmcp-6d14ac69-538e-47bf-4c58-76751357173b.tmp: Couldn't create shell: unknown error Post http://127.0.0.1:3674/wsman: EOF
```

I'll try to figure this out but published the branch so others can try too.