### PR TITLE
Set some effective VirtualBox defaults for windows

### DIFF
--- a/malboxes/profiles/snippets/builder_virtualbox_windows.json
+++ b/malboxes/profiles/snippets/builder_virtualbox_windows.json
@@ -9,7 +9,9 @@
 		"shutdown_command": "shutdown /s /f /t 10",
 		"vboxmanage": [
 			["modifyvm", "{{ '{{.Name}}' }}", "--memory", "4096"],
-			["modifyvm", "{{ '{{.Name}}' }}", "--cpus", "1"]
+			["modifyvm", "{{ '{{.Name}}' }}", "--cpus", "1"],
+			["modifyvm", "{{ '{{.Name}}' }}", "--cpuexecutioncap", "80"],
+			["modifyvm", "{{ '{{.Name}}' }}", "--vram", "128"]		
 		],
 		"boot_wait": "10s",
 		"disk_size": "{{ disk_size }}",


### PR DESCRIPTION
These values worked well for me in some Win7 experiments today and this seems to be the best place for them.

VMem is set elsewhere, but seems to work here, and CPU execution cap helps keep VMs from impacting Host/OS (though the value to set is arbitrary). I really want detachable GUI, still working on it :)

hth,
adric

Refs:
* https://www.vagrantup.com/docs/virtualbox/configuration.html
* https://www.virtualbox.org/manual/ch08.htm