### PR TITLE
VirtualBox Guest Additions: Support for the new certificate name

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@ Bug fixes::
   * Packer binary is called `packer-io` on certain platforms ({uri-issue}3[#3])
   * Windows 10 x86 Automatic Installation issues ({uri-issue}4[#4])
   * Temporarily removed depwalker and regshot from choco packages ({uri-issue}16[#16])
+  * VirtualBox Guest Additions: Support for the new certificate name ({uri-issue}24[#24])
 
 ////
 

--- a/malboxes/scripts/windows/vmtools.ps1
+++ b/malboxes/scripts/windows/vmtools.ps1
@@ -2,5 +2,12 @@ $vboxAdditionsDrive = Get-WmiObject Win32_LogicalDisk -Filter "DriveType=5" |
 			Where-Object { $_.VolumeName -Like '*VBOX*' } |
 			Select -ExpandProperty DeviceID
 
-&certutil -addstore -f "TrustedPublisher" "$vboxAdditionsDrive\cert\oracle-vbox.cer"
+# Starting with VirtualBox 5.1.12 the name of the certificate changed
+$newCertName = "vbox-sha1.cer"
+if (Test-Path "$vboxAdditionsDrive\cert\$newCertName") {
+    &certutil -addstore -f "TrustedPublisher" "$vboxAdditionsDrive\cert\$newCertName"
+}
+else {
+    &certutil -addstore -f "TrustedPublisher" "$vboxAdditionsDrive\cert\oracle-vbox.cer"
+}
 &"$vboxAdditionsDrive\VBoxWindowsAdditions.exe" /S


### PR DESCRIPTION
Supports both 5.1.12 and previous certificate names by testing for the file existence.

Fixes #24 