### PR TITLE
packer: add -on-error=abort when running malboxes in debug mode (#35)

### DIFF
--- a/malboxes/malboxes.py
+++ b/malboxes/malboxes.py
@@ -317,12 +317,13 @@ def run_packer(packer_tmpl, args):
             f.write(jsmin(config.read()))
             f.close()
 
+        flags = ['-var-file={}'.format(f.name)]
+
         if DEBUG:
             special_env = {'PACKER_LOG': '1'}
+            flags.append('-on-error=abort')
         else:
             special_env = None
-
-        flags = ['-var-file={}'.format(f.name)]
 
         cmd = [binary, 'build']
         cmd.extend(flags)


### PR DESCRIPTION
This eases further investigation on what went wrong. Otherwise, the VM is destroyed by packer.

Worked better than #36 and is less maintenance than duplicating all profiles.