### PR TITLE
Bugfix windows7 network profile

### DIFF
--- a/docs/devel.adoc
+++ b/docs/devel.adoc
@@ -14,6 +14,7 @@ branch to test in the following command:
 
     pip3 install --upgrade git+https://github.com/GoSecure/malboxes.git@branchname#egg=malboxes
 
+
 == Making a release
 
 . Update the version in `malboxes/_version.py`
@@ -34,3 +35,36 @@ branch to test in the following command:
 
 . Update version in `malboxes/_version.py` (+1 feature, append 'dev') and commit
 ** commit msg: Begin development on next release
+
+
+== VirtualBox Management Commands
+
+Useful commands:
+
+    VBoxManage list vms
+
+    VBoxManage showvminfo <vm>
+
+    VBoxManage controlvm packer-virtualbox-iso-1488033522 poweroff
+
+If that doesn't work, kill the VBoxHeadless process.
+
+    VBoxManage unregistervm --delete <vm>
+
+
+== How to View Errors from Scripts Called from Autounattend.xml
+
+=== PowerShell
+
+Add this to the end of PowerShell scripts:
+
+    Write-Host "Press any key to continue ..."
+    $x = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyUp")
+
+This will pause scripts allowing you to see the output.
+
+=== Command (cmd.exe)
+
+    PAUSE
+
+Will stop a batch script execution until a key is pressed.

--- a/malboxes/installconfig/windows7/Autounattend.xml
+++ b/malboxes/installconfig/windows7/Autounattend.xml
@@ -89,12 +89,24 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>2</Order>
+                    <Description>Disable Network Prompt</Description>
+                    <CommandLine>cmd.exe /c reg add "HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff"</CommandLine>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <Description>Mark all networks as private</Description>
+                    <CommandLine>cmd.exe /c powershell -File a:\fixnetworks.ps1</CommandLine>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>4</Order>
 		    <CommandLine>cmd.exe /c wmic useraccount where &quot;name=&apos;{{ username }}&apos;&quot; set PasswordExpires=FALSE</CommandLine>
 		    <Description>Disable password expiration for user {{ username }}</Description>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>3</Order>
+                    <Order>5</Order>
                     <CommandLine>cmd.exe /c powershell -File &quot;A:\enablewinrm.ps1&quot;</CommandLine>
                     <Description>Enable WinRM for Packer/Vagrant communicator</Description>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/malboxes/installconfig/windows7/Autounattend.xml
+++ b/malboxes/installconfig/windows7/Autounattend.xml
@@ -80,6 +80,31 @@
                 <Enabled>true</Enabled>
 		<Username>{{ username }}</Username>
             </AutoLogon>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <ProtectYourPC>3</ProtectYourPC>
+                <NetworkLocation>Home</NetworkLocation>
+            </OOBE>
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>{{ password }}</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>{{ password }}</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+			<DisplayName>{{ username }}</DisplayName>
+                        <Group>Administrators</Group>
+			<Name>{{ username }}</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+            </UserAccounts>
+            <RegisteredOwner>{{ username }}</RegisteredOwner>
+            <TimeZone>Eastern Standard Time</TimeZone>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
                     <Order>1</Order>
@@ -112,31 +137,6 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
-            <OOBE>
-                <HideEULAPage>true</HideEULAPage>
-                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
-                <ProtectYourPC>3</ProtectYourPC>
-                <NetworkLocation>Home</NetworkLocation>
-            </OOBE>
-            <UserAccounts>
-                <AdministratorPassword>
-                    <Value>{{ password }}</Value>
-                    <PlainText>true</PlainText>
-                </AdministratorPassword>
-                <LocalAccounts>
-                    <LocalAccount wcm:action="add">
-                        <Password>
-                            <Value>{{ password }}</Value>
-                            <PlainText>true</PlainText>
-                        </Password>
-			<DisplayName>{{ username }}</DisplayName>
-                        <Group>Administrators</Group>
-			<Name>{{ username }}</Name>
-                    </LocalAccount>
-                </LocalAccounts>
-            </UserAccounts>
-	    <RegisteredOwner>{{ username }}</RegisteredOwner>
-            <TimeZone>Eastern Standard Time</TimeZone>
         </component>
     </settings>
     <settings pass="specialize">

--- a/malboxes/installconfig/windows7/enablewinrm.ps1
+++ b/malboxes/installconfig/windows7/enablewinrm.ps1
@@ -28,5 +28,5 @@ winrm set winrm/config/service/auth '@{Basic="true"}'
 net stop winrm
 netsh advfirewall firewall set rule group="remote administration" new enable=yes
 netsh firewall add portopening TCP 5985 "Port 5985"
-sc.exe config winrm start=auto
+sc.exe config winrm start= auto
 net start winrm

--- a/malboxes/installconfig/windows7/enablewinrm.ps1
+++ b/malboxes/installconfig/windows7/enablewinrm.ps1
@@ -1,4 +1,25 @@
-Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private
+// ChangeCategory.ps1
+//
+$NLMType = [Type]::GetTypeFromCLSID('DCB00C01-570F-4A9B-8D69-199FDBA5723B')
+$INetworkListManager = [Activator]::CreateInstance($NLMType)
+
+$NLM_ENUM_NETWORK_CONNECTED  = 1
+$NLM_NETWORK_CATEGORY_PUBLIC = 0x00
+$NLM_NETWORK_CATEGORY_PRIVATE = 0x01
+$UNIDENTIFIED = "Unidentified network"
+
+$INetworks = $INetworkListManager.GetNetworks($NLM_ENUM_NETWORK_CONNECTED)
+
+foreach ($INetwork in $INetworks)
+{
+    $Name = $INetwork.GetName()
+    $Category = $INetwork.GetCategory()
+
+    if ($INetwork.IsConnected -and ($Category -eq $NLM_NETWORK_CATEGORY_PUBLIC) -and ($Name -eq $UNIDENTIFIED))
+    {
+        $INetwork.SetCategory($NLM_NETWORK_CATEGORY_PRIVATE)
+    }
+}
 
 winrm quickconfig -q -transport:http
 winrm set winrm/config/client '@{AllowUnencrypted="true"}'

--- a/malboxes/installconfig/windows7/enablewinrm.ps1
+++ b/malboxes/installconfig/windows7/enablewinrm.ps1
@@ -1,26 +1,3 @@
-// ChangeCategory.ps1
-//
-$NLMType = [Type]::GetTypeFromCLSID('DCB00C01-570F-4A9B-8D69-199FDBA5723B')
-$INetworkListManager = [Activator]::CreateInstance($NLMType)
-
-$NLM_ENUM_NETWORK_CONNECTED  = 1
-$NLM_NETWORK_CATEGORY_PUBLIC = 0x00
-$NLM_NETWORK_CATEGORY_PRIVATE = 0x01
-$UNIDENTIFIED = "Unidentified network"
-
-$INetworks = $INetworkListManager.GetNetworks($NLM_ENUM_NETWORK_CONNECTED)
-
-foreach ($INetwork in $INetworks)
-{
-    $Name = $INetwork.GetName()
-    $Category = $INetwork.GetCategory()
-
-    if ($INetwork.IsConnected -and ($Category -eq $NLM_NETWORK_CATEGORY_PUBLIC) -and ($Name -eq $UNIDENTIFIED))
-    {
-        $INetwork.SetCategory($NLM_NETWORK_CATEGORY_PRIVATE)
-    }
-}
-
 winrm quickconfig -q -transport:http
 winrm set winrm/config/client '@{AllowUnencrypted="true"}'
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'

--- a/malboxes/malboxes.py
+++ b/malboxes/malboxes.py
@@ -55,7 +55,8 @@ def init_parser():
                                 "and config generator for malware analysis.")
     parser.add_argument('-V', '--version', action='version',
                         version='%(prog)s ' + __version__)
-    parser.add_argument('-d', '--debug', action='store_true', help="Debug mode")
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help="Debug mode. Leaves built VMs running on failure!")
     subparsers = parser.add_subparsers()
 
     # list command

--- a/malboxes/profiles/win7_32_analyst.json
+++ b/malboxes/profiles/win7_32_analyst.json
@@ -9,7 +9,8 @@
 
 		"floppy_files": [
 			"{{ cache_dir }}/Autounattend.xml",
-			"{{ dir }}/installconfig/windows7/enablewinrm.ps1"
+			"{{ dir }}/installconfig/windows7/enablewinrm.ps1",
+			"{{ dir }}/scripts/windows/fixnetworks.ps1"
 		]
 	}],
 

--- a/malboxes/scripts/windows/fixnetworks.ps1
+++ b/malboxes/scripts/windows/fixnetworks.ps1
@@ -1,0 +1,28 @@
+# From packer-windows project
+# https://github.com/joefitzgerald/packer-windows/blob/a2b9d6fdd91a857d605fb1d7ec822f3fdfa71db4/scripts/fixnetwork.ps1
+# Licensed under the MIT License
+# Copyright (c) 2014 Joe Fitzgerald
+
+# You cannot enable Windows PowerShell Remoting on network connections that are set to Public
+# Spin through all the network locations and if they are set to Public, set them to Private
+# using the INetwork interface:
+# http://msdn.microsoft.com/en-us/library/windows/desktop/aa370750(v=vs.85).aspx
+# For more info, see:
+# http://blogs.msdn.com/b/powershell/archive/2009/04/03/setting-network-location-to-private.aspx
+
+# Network location feature was only introduced in Windows Vista - no need to bother with this
+# if the operating system is older than Vista
+if([environment]::OSVersion.version.Major -lt 6) { return }
+
+# You cannot change the network location if you are joined to a domain, so abort
+if(1,3,4,5 -contains (Get-WmiObject win32_computersystem).DomainRole) { return }
+
+# Get network connections
+$networkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}"))
+$connections = $networkListManager.GetNetworkConnections()
+
+$connections |foreach {
+	Write-Host $_.GetNetwork().GetName()"category was previously set to"$_.GetNetwork().GetCategory()
+	$_.GetNetwork().SetCategory(1)
+	Write-Host $_.GetNetwork().GetName()"changed to category"$_.GetNetwork().GetCategory()
+}


### PR DESCRIPTION
* New PowerShell script to set the NetworkLocation on installation. Every interface will be set to "private" which enables WinRM to run (otherwise WinRM config fails). Run as a FirstLogin script right before enabling WinRM. Fixes #33.
* Doc: Added some helpful hints to debug problems with `Autounattend.xml` FirstLogin scripts
* Doc: Added a note that `--debug` leave VMs running