### PR TITLE
bugfix: Increasing WinRM memory limit for .Net 4.0 install (fixes #31)

### DIFF
--- a/malboxes/installconfig/windows7/enablewinrm.ps1
+++ b/malboxes/installconfig/windows7/enablewinrm.ps1
@@ -4,6 +4,8 @@ winrm quickconfig -q -transport:http
 winrm set winrm/config/client '@{AllowUnencrypted="true"}'
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'
 winrm set winrm/config/service/auth '@{Basic="true"}'
+# .Net 4.0 installer (a choco dep) fails w/o this amount of memory (#31)
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="800"}'
 net stop winrm
 netsh advfirewall firewall set rule group="remote administration" new enable=yes
 netsh firewall add portopening TCP 5985 "Port 5985"


### PR DESCRIPTION
Chocolatey on Windows 7 pulled in .Net 4.0 and it was unable to install due to memory limits for scripts.

Such a small fix for such a long investigation...