### PR TITLE
Reverse the order of searching for packer-io, otherwise on Fedora/Red…

### DIFF
--- a/malboxes/malboxes.py
+++ b/malboxes/malboxes.py
@@ -303,9 +303,9 @@ def run_packer(packer_tmpl, args):
 
     try:
         # packer or packer-io?
-        binary = 'packer'
+        binary = 'packer-io'
         if shutil.which(binary) == None:
-            binary = 'packer-io'
+            binary = 'packer'
             if shutil.which(binary) == None:
                 print("packer not found. Install it: "
                       "https://www.packer.io/intro/getting-started/setup.html")

--- a/malboxes/vagrantfiles/analyst_single.rb
+++ b/malboxes/vagrantfiles/analyst_single.rb
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 Vagrant.configure(2) do |config|
 	config.vm.box = "{{ profile }}"
 	config.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
Hello,
the patch 0e0255f is not working properly on the Fedora/Redhat/Centos, because it always picks the colliding packer from the cracklib package.

I would recommend to reverse the order of searching for packer starting with more specific 'packer-io' and then fallback to 'packer'.

Best regards
Michal Ambroz