### PR TITLE
Added support for defining custom provisioners in profile

### DIFF
--- a/malboxes/malboxes.py
+++ b/malboxes/malboxes.py
@@ -487,6 +487,11 @@ def prepare_profile(template, config):
         for package_mod in profile["package"]:
             package(profile_name, package_mod["package"], fd)
 
+    if "packer" in profile:
+        packer = profile["packer"]
+        if "provisioners" in packer:
+            config["packer_extra_provisioners"] = packer["provisioners"]
+
     fd.close()
     return config
 

--- a/malboxes/profile-example.js
+++ b/malboxes/profile-example.js
@@ -13,5 +13,14 @@
         {"modtype": "delete", "key": "HKLM:\\SYSTEM\\ControlSet001\\Services", "name": "VBoxService"},
         {"modtype": "delete", "key": "HKLM:\\SYSTEM\\ControlSet001\\Services", "name": "VBoxSF"},
         {"modtype": "delete", "key": "HKLM:\\SYSTEM\\ControlSet001\\Services", "name": "VBoxVideo"},
-        {"modtype": "add", "key": "HKLM:\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0", "value": "Malboxes", "name": "Identifier", "valuetype": "String"}]
+        {"modtype": "add", "key": "HKLM:\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0", "value": "Malboxes", "name": "Identifier", "valuetype": "String"}],
+    "packer": {
+        "_comment": "See https://www.packer.io/docs/templates/provisioners.html for syntax"
+        "provisioners": [
+            {
+                "type": "powershell",
+                "inline": ["dir c:\\"]
+            }
+        ]
+    }
 }

--- a/malboxes/templates/win10_32_analyst.json
+++ b/malboxes/templates/win10_32_analyst.json
@@ -38,6 +38,10 @@
 		{% if ida_path %},
 			{% include 'snippets/ida_remote_32.json' %}
 		{% endif %}
-
+		{% if packer_extra_provisioners %}
+			{% for p in packer_extra_provisioners %}
+				,{{ p | tojson }}
+			{% endfor %}
+		{% endif %}
 	]
 }

--- a/malboxes/templates/win10_64_analyst.json
+++ b/malboxes/templates/win10_64_analyst.json
@@ -37,6 +37,10 @@
 			{% include 'snippets/ida_remote_64.json' %},
 			{% include 'snippets/ida_remote_32.json' %}
 		{% endif %}
-
+		{% if packer_extra_provisioners %}
+			{% for p in packer_extra_provisioners %}
+				,{{ p | tojson }}
+			{% endfor %}
+		{% endif %}
 	]
 }

--- a/malboxes/templates/win7_32_analyst.json
+++ b/malboxes/templates/win7_32_analyst.json
@@ -34,6 +34,10 @@
 	{% if ida_path %},
 		{% include 'snippets/ida_remote_32.json' %}
 	{% endif %}
-
+	{% if packer_extra_provisioners %}
+		{% for p in packer_extra_provisioners %}
+			,{{ p | tojson }}
+		{% endfor %}
+	{% endif %}
 	]
 }

--- a/malboxes/templates/win7_64_analyst.json
+++ b/malboxes/templates/win7_64_analyst.json
@@ -31,10 +31,14 @@
 	{% if tools_path %},
 		{% include 'snippets/tools.json' %}
 	{% endif %}
-        {% if ida_path %},
-                {% include 'snippets/ida_remote_64.json' %},
-                {% include 'snippets/ida_remote_32.json' %}
-        {% endif %}
-
+	{% if ida_path %},
+		{% include 'snippets/ida_remote_64.json' %},
+		{% include 'snippets/ida_remote_32.json' %}
+	{% endif %}
+	{% if packer_extra_provisioners %}
+		{% for p in packer_extra_provisioners %}
+			,{{ p | tojson }}
+		{% endfor %}
+	{% endif %}
 	]
 }


### PR DESCRIPTION
I made the packer provisioning area customizable using the profile.

I added a packer section:
```
    "packer": {
        "_comment": "See https://www.packer.io/docs/templates/provisioners.html for syntax"
        "provisioners": [
            {
                "type": "powershell",
                "inline": ["dir c:\\"]
            }
        ]
    }
```
Which is copied at the end of the packer.json templates.
It allows users to add custom powershell commands (or even scripts) directly.

We use this to push custom packages (using a custom repository) using chocolatey.