### PR TITLE
Force Chocolatey to use the proxy settings

### DIFF
--- a/malboxes/templates/snippets/provision_powershell.json
+++ b/malboxes/templates/snippets/provision_powershell.json
@@ -15,6 +15,10 @@
 	{
 		"type": "windows-shell",
 		"inline": [
+			{% if proxy %}
+				{# Sometimes, choco decide to ignore the proxy... #}
+				"choco config set proxy {{ proxy }}",
+			{% endif %}
 			"choco install npcap --package-parameters '/winpcap_mode=yes' -y",
 			"choco install {{ choco_packages }} -y"
 		]

--- a/malboxes/templates/snippets/provision_powershell_win7.json
+++ b/malboxes/templates/snippets/provision_powershell_win7.json
@@ -34,6 +34,10 @@
 	{
 		"type": "windows-shell",
 		"inline": [
+			{% if proxy %}
+				{# Sometimes, choco decide to ignore the proxy... #}
+				"choco config set proxy {{ proxy }}",
+			{% endif %}
 			"choco install npcap --package-parameters '/winpcap_mode=yes' -y",
 			"choco install {{ choco_packages }} -y"
 		]


### PR DESCRIPTION
  Sometimes, chocolatey decides to ignore the proxy settings,
  The best way is to force it is through `choco config`

  $ choco config set proxy proxy_address:3128