### PR TITLE
choco_packages: split config into a list

### DIFF
--- a/malboxes/config-example.js
+++ b/malboxes/config-example.js
@@ -55,7 +55,19 @@
 
 	// Chocolatey packages to install on the VM
 	// TODO re-add dependencywalker and regshot once upstream choco package provides a checksum
-	"choco_packages": "sysinternals windbg 7zip putty fiddler4 processhacker apm wireshark",
+	"choco_packages": [
+		// "dependencywalker --ignorechecksum",
+		// "regshot --ignorechecksum",
+		"npcap --package-parameters '/winpcap_mode=yes'",
+		"sysinternals",
+		"windbg",
+		"7zip",
+		"putty",
+		"fiddler4",
+		"processhacker",
+		"apm",
+		"wireshark"
+	],
 
 	// Setting the IDA Path will copy the IDA remote debugging tools into the guest
 	//"ida_path": "/path/to/your/ida",

--- a/malboxes/config-example.js
+++ b/malboxes/config-example.js
@@ -55,6 +55,7 @@
 
 	// Chocolatey packages to install on the VM
 	// TODO re-add dependencywalker and regshot once upstream choco package provides a checksum
+	// "choco_packages": False,
 	"choco_packages": [
 		// "dependencywalker --ignorechecksum",
 		// "regshot --ignorechecksum",

--- a/malboxes/malboxes.py
+++ b/malboxes/malboxes.py
@@ -315,10 +315,13 @@ def run_packer(packer_tmpl, args):
                 return 254
 
         # run packer with relevant config minified
+        # (removes "choco_packages" as packer do not support arrays in var-file)
         configfile = os.path.join(DIRS.user_config_dir, 'config.js')
         with open(configfile, 'r') as config:
+            config = json.loads(jsmin(config.read()))
+            del config['choco_packages']
             f = create_cachefd('packer_var_file.json')
-            f.write(jsmin(config.read()))
+            f.write(json.dumps(config))
             f.close()
 
         flags = ['-var-file={}'.format(f.name)]

--- a/malboxes/templates/snippets/provision_powershell.json
+++ b/malboxes/templates/snippets/provision_powershell.json
@@ -19,8 +19,15 @@
 				{# Sometimes, choco decide to ignore the proxy... #}
 				"choco config set proxy {{ proxy }}",
 			{% endif %}
-			"choco install npcap --package-parameters '/winpcap_mode=yes' -y",
-			"choco install {{ choco_packages }} -y"
+			{% if choco_packages is iterable and choco_packages is not string %}
+				{% for package in choco_packages %}
+					"choco install {{ package }} -y"{{ "," if not loop.last }}
+				{% endfor %}
+			{% else %}
+				{# Support old config format #}
+				"choco install npcap --package-parameters '/winpcap_mode=yes' -y",
+				"choco install {{ choco_packages }} -y"
+			{% endif %}
 		]
 	}
 {% endif %}

--- a/malboxes/templates/snippets/provision_powershell.json
+++ b/malboxes/templates/snippets/provision_powershell.json
@@ -6,12 +6,14 @@
 			{% if hypervisor == "virtualbox" %}
 				"{{ dir }}/scripts/windows/vmtools.ps1",
 			{% endif %}
-			"{{ dir }}/scripts/windows/installtools.ps1",
+			{% if choco_packages and choco_packages|length > 0 %}
+				"{{ dir }}/scripts/windows/installtools.ps1",
+			{% endif %}
 			{% if profile is defined %}"{{ cache_dir }}/profile-{{ profile }}.ps1",{% endif %}
 			"{{ dir }}/scripts/windows/malware_analysis.ps1"
 		]
 	}
-{% if choco_packages %},
+{% if choco_packages and choco_packages|length > 0 %},
 	{
 		"type": "windows-shell",
 		"inline": [

--- a/malboxes/templates/snippets/provision_powershell_win7.json
+++ b/malboxes/templates/snippets/provision_powershell_win7.json
@@ -38,8 +38,15 @@
 				{# Sometimes, choco decide to ignore the proxy... #}
 				"choco config set proxy {{ proxy }}",
 			{% endif %}
-			"choco install npcap --package-parameters '/winpcap_mode=yes' -y",
-			"choco install {{ choco_packages }} -y"
+			{% if choco_packages is iterable and choco_packages is not string %}
+				{% for package in choco_packages %}
+					"choco install {{ package }} -y"{{ "," if not loop.last }}
+				{% endfor %}
+			{% else %}
+				{# Support old config format #}
+				"choco install npcap --package-parameters '/winpcap_mode=yes' -y",
+				"choco install {{ choco_packages }} -y"
+			{% endif %}
 		]
 	}
 {% endif %}

--- a/malboxes/templates/snippets/provision_powershell_win7.json
+++ b/malboxes/templates/snippets/provision_powershell_win7.json
@@ -9,15 +9,17 @@
 			{% endif %}
 		]
 	},
-	{
-		"type": "powershell",
-		"elevated_user": "{{ username }}",
-		"elevated_password": "{{ password }}",
-		"scripts": [
-			"{{ dir }}/scripts/windows/installtools.ps1"
-		],
-		"valid_exit_codes": [ 0, 5888 ]
-	},
+	{% if choco_packages and choco_packages|length > 0 %}
+		{
+			"type": "powershell",
+			"elevated_user": "{{ username }}",
+			"elevated_password": "{{ password }}",
+			"scripts": [
+				"{{ dir }}/scripts/windows/installtools.ps1"
+			],
+			"valid_exit_codes": [ 0, 5888 ]
+		},
+	{% endif %}
 	{
 		"type": "windows-restart"
 	}
@@ -30,7 +32,7 @@
 		]
 	}
 {% endif %}
-{% if choco_packages %},
+{% if choco_packages and choco_packages|length > 0 %},
 	{
 		"type": "windows-shell",
 		"inline": [


### PR DESCRIPTION
I modified the default config to allow splitting of `choco_packages`.

This idea is to allow to pass options to each package directly (to disallow checksums, specify package options, etc.)