### PR TITLE
Workaround for proxy support in Windows 7

### DIFF
--- a/malboxes/installconfig/windows7/Autounattend.xml
+++ b/malboxes/installconfig/windows7/Autounattend.xml
@@ -72,7 +72,7 @@
     </settings>
     <settings pass="oobeSystem">
         {% if proxy %}
-        <component name="Microsoft-Windows-IE-ClientNetworkProtocolImplementation" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+        <component name="Microsoft-Windows-IE-ClientNetworkProtocolImplementation" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <POLICYProxySettingsPerUser>0</POLICYProxySettingsPerUser>
             <HKLMProxyEnable>true</HKLMProxyEnable>
             <HKLMProxyServer>{{ proxy }}</HKLMProxyServer>
@@ -131,8 +131,16 @@
 		    <Description>Disable password expiration for user {{ username }}</Description>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
+                {% if proxy %}
+                    <SynchronousCommand wcm:action="add">
+                        <Order>4</Order>
+                        <CommandLine>cmd.exe /c powershell -File &quot;A:\refresh-proxy.ps1&quot;</CommandLine>
+                        <Description>Refresh Proxy Settings</Description>
+                        <RequiresUserInput>true</RequiresUserInput>
+                    </SynchronousCommand>
+                {% endif %}
                 <SynchronousCommand wcm:action="add">
-                    <Order>4</Order>
+                    <Order>5</Order>
                     <CommandLine>cmd.exe /c powershell -File &quot;A:\enablewinrm.ps1&quot;</CommandLine>
                     <Description>Enable WinRM for Packer/Vagrant communicator</Description>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/malboxes/installconfig/windows7_64/Autounattend.xml
+++ b/malboxes/installconfig/windows7_64/Autounattend.xml
@@ -72,7 +72,7 @@
     </settings>
     <settings pass="oobeSystem">
         {% if proxy %}
-        <component name="Microsoft-Windows-IE-ClientNetworkProtocolImplementation" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+        <component name="Microsoft-Windows-IE-ClientNetworkProtocolImplementation" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <POLICYProxySettingsPerUser>0</POLICYProxySettingsPerUser>
             <HKLMProxyEnable>true</HKLMProxyEnable>
             <HKLMProxyServer>{{ proxy }}</HKLMProxyServer>
@@ -131,8 +131,16 @@
 		    <Description>Disable password expiration for user {{ username }}</Description>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
+                {% if proxy %}
+                    <SynchronousCommand wcm:action="add">
+                        <Order>4</Order>
+                        <CommandLine>cmd.exe /c powershell -File &quot;A:\refresh-proxy.ps1&quot;</CommandLine>
+                        <Description>Refresh Proxy Settings</Description>
+                        <RequiresUserInput>true</RequiresUserInput>
+                    </SynchronousCommand>
+                {% endif %}
                 <SynchronousCommand wcm:action="add">
-                    <Order>4</Order>
+                    <Order>5</Order>
                     <CommandLine>cmd.exe /c powershell -File &quot;A:\enablewinrm.ps1&quot;</CommandLine>
                     <Description>Enable WinRM for Packer/Vagrant communicator</Description>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/malboxes/scripts/windows/refresh-proxy.ps1
+++ b/malboxes/scripts/windows/refresh-proxy.ps1
@@ -1,0 +1,55 @@
+# Windows...
+#
+# Here is a note to someone wondering what we're doing _here_
+# (And why we're doing it here and now)
+#
+# Windows7 supports proxy configuration through Autounattend.xml
+# Unattended install sets everything needed to have a system-wide proxy
+# configuration.
+#
+# The problem seems to be that it fails to notify wininet subsystems of the
+# configuration. Which can prevent us from accessing the Internet.
+# (sometimes or always, it depends, I don't really know)
+#
+# This piece of code can't be run through WinRM for some reason. Running it
+# through WinRM will result in Windows removing `ProxyEnable` and `ProxyServer`
+# keys from the registry <--- O_o
+#
+# Anyway, in order to MakeItWork(tm) we need to run this interactively.
+#
+# These dark spells of black witchcraftery should be enough to allow
+# Windows/IE/Wininet/Whatever to get the right memo and use the configured
+# proxy
+#
+
+echo "Proxy is: $([Net.GlobalProxySelection]::Select.Address.Host)"
+
+$signature = @'
+[DllImport("wininet.dll", SetLastError = true, CharSet=CharSet.Auto)]
+public static extern bool InternetSetOption(IntPtr hInternet, int dwOption, IntPtr lpBuffer, int dwBufferLength);
+'@
+$wininet = Add-Type -MemberDefinition $signature -Name wininet -Namespace pinvoke -PassThru
+
+function Refresh-System
+{
+    $INTERNET_OPTION_SETTINGS_CHANGED   = 39
+    $INTERNET_OPTION_REFRESH            = 37
+    $INTERNET_OPTION_PROXY_SETTINGS_CHANGED = 95
+    $a = $wininet::InternetSetOption(0, $INTERNET_OPTION_SETTINGS_CHANGED, 0, 0)
+    $b = $wininet::InternetSetOption(0, $INTERNET_OPTION_PROXY_SETTINGS_CHANGED, 0, 0)
+    $c = $wininet::InternetSetOption(0, $INTERNET_OPTION_REFRESH, 0, 0)
+}
+
+function Test-Connection
+{
+    $ie = New-Object -comobject InternetExplorer.Application;
+    $ie.visible=$False;
+    $ie.navigate('http://google.com');
+    start-sleep -s 5;
+    $ie.quit();
+}
+
+Refresh-System
+Test-Connection
+
+echo "Proxy is: $([Net.GlobalProxySelection]::Select.Address.Host)"

--- a/malboxes/templates/snippets/provision_powershell.json
+++ b/malboxes/templates/snippets/provision_powershell.json
@@ -15,10 +15,6 @@
 	{
 		"type": "windows-shell",
 		"inline": [
-			{% if proxy %}
-				{# Sometimes, choco decide to ignore the proxy... #}
-				"choco config set proxy {{ proxy }}",
-			{% endif %}
 			"choco install npcap --package-parameters '/winpcap_mode=yes' -y",
 			"choco install {{ choco_packages }} -y"
 		]

--- a/malboxes/templates/snippets/provision_powershell_win7.json
+++ b/malboxes/templates/snippets/provision_powershell_win7.json
@@ -34,10 +34,6 @@
 	{
 		"type": "windows-shell",
 		"inline": [
-			{% if proxy %}
-				{# Sometimes, choco decide to ignore the proxy... #}
-				"choco config set proxy {{ proxy }}",
-			{% endif %}
 			"choco install npcap --package-parameters '/winpcap_mode=yes' -y",
 			"choco install {{ choco_packages }} -y"
 		]

--- a/malboxes/templates/win7_32_analyst.json
+++ b/malboxes/templates/win7_32_analyst.json
@@ -18,6 +18,7 @@
 
 		"floppy_files": [
 			"{{ cache_dir }}/Autounattend.xml",
+			{% if proxy %}"{{ dir }}/scripts/windows/refresh-proxy.ps1",{% endif %}
 			"{{ dir }}/installconfig/windows7/enablewinrm.ps1"
 		]
 	}],

--- a/malboxes/templates/win7_64_analyst.json
+++ b/malboxes/templates/win7_64_analyst.json
@@ -18,6 +18,7 @@
 
 		"floppy_files": [
 			"{{ cache_dir }}/Autounattend.xml",
+			{% if proxy %}"{{ dir }}/scripts/windows/refresh-proxy.ps1",{% endif %}
 			"{{ dir }}/installconfig/windows7_64/enablewinrm.ps1"
 		]
 	}],


### PR DESCRIPTION
Windows7 supports proxy configuration through `Autounattend.xml`
Unattended install sets everything needed to have a system-wide proxy
configuration.

The problem seems to be that it fails to notify `wininet` subsystem
(sometimes or always, it depends, I don't really know why/how exactly)

Anyways, this patch allow chocolatey to work **reliably** behind a proxy