### PR TITLE
Fix Jinja2 version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 appdirs
-Jinja2
+Jinja2>=2.9
 jsmin


### PR DESCRIPTION
The `tojson` feature needs Jinja at least 2.9 (Should fix #80)