### PR TITLE
Fixed default profile use.

### DIFF
--- a/malboxes/malboxes.py
+++ b/malboxes/malboxes.py
@@ -192,11 +192,10 @@ def prepare_config(template):
 
     config = load_config(config_file, template)
 
-    if "profile" in config.keys():
-        profile_config = prepare_profile(template, config)
+    profile_config = prepare_profile(template, config)
 
-        # profile_config might contain a profile not in the config file
-        config.update(profile_config)
+    # profile_config might contain a profile not in the config file
+    config.update(profile_config)
 
     packer_tmpl = prepare_packer_template(config, template)
 


### PR DESCRIPTION
The fix to #87 . I deleted the if clause so that, if no profile is specified in the config, the `profile-example.js` is used.