### PR TITLE
use PACKER_CACHE_DIR env var if already set

### DIFF
--- a/malboxes/malboxes.py
+++ b/malboxes/malboxes.py
@@ -323,7 +323,8 @@ def run_packer(packer_tmpl, args):
 
         flags = ['-var-file={}'.format(f.name)]
 
-        special_env = {'PACKER_CACHE_DIR': DIRS.user_cache_dir}
+        packer_cache_dir = os.getenv('PACKER_CACHE_DIR', DIRS.user_cache_dir)
+        special_env = {'PACKER_CACHE_DIR': packer_cache_dir}
         special_env['TMPDIR'] = DIRS.user_cache_dir
         if DEBUG:
             special_env['PACKER_LOG']  = '1'


### PR DESCRIPTION
This PR checks for the value of `PACKER_CACHE_DIR` first, and then defaults to `DIRS.user_cache_dir`.

Solves https://github.com/GoSecure/malboxes/issues/99

You can review it, i'm testing it right now.