### PR TITLE
Goodbye Python 3.3. Hello 3.5 and 3.6!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-- '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 install: pip install -r requirements.txt && pip install pylint
 sudo: false
 script: make test


### PR DESCRIPTION
Apparently Travis still doesn't support 3.7 so we are going to wait for that.