### PR TITLE
bugfix: Tolerate 404 errors on chocolatey installs

### DIFF
--- a/malboxes/templates/snippets/provision_powershell.json
+++ b/malboxes/templates/snippets/provision_powershell.json
@@ -13,9 +13,10 @@
 	}
 {% if choco_packages %},
 	{
-		"type": "windows-shell",
+		"type": "powershell",
 		"inline": [
 			"choco install {{ choco_packages }} -y"
-		]
+		],
+		"valid_exit_codes": [ 0, 404 ]
 	}
 {% endif %}

--- a/malboxes/templates/snippets/provision_powershell_win7.json
+++ b/malboxes/templates/snippets/provision_powershell_win7.json
@@ -32,10 +32,11 @@
 {% endif %}
 {% if choco_packages %},
 	{
-		"type": "windows-shell",
+		"type": "powershell",
 		"inline": [
 			"choco install npcap --package-parameters '/winpcap_mode=yes' -y",
 			"choco install {{ choco_packages }} -y"
-		]
+		],
+		"valid_exit_codes": [ 0, 404 ]
 	}
 {% endif %}


### PR DESCRIPTION
They happen way too often and break entire builds. I think we can tolerate them for now.