### PR TITLE
Travis CI successfully builds Windows 7 and other improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,5 +16,13 @@ pipeline {
                 sh 'tests/smoke/build-all-templates.sh'
             }
         }
+        stage('Clean') {
+            agent any
+            steps {
+                dir('/var/jenkins_home/.cache/malboxes/') {
+                    deleteDir()
+                }
+            }
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
                 dockerfile {
                     filename 'Dockerfile'
                     dir 'tests/smoke'
-                    args '-v /dev/vboxdrv:/dev/vboxdrv --privileged'
+                    args '-v /dev/vboxdrv:/dev/vboxdrv -v /tmp:/tmp --network host --privileged'
                 }
             }
             steps {

--- a/tests/smoke/Dockerfile
+++ b/tests/smoke/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends virtualbox python3 python3-pip python3-setuptools wget unzip bash git && \
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates gnupg && \
+    curl -sSL https://www.virtualbox.org/download/oracle_vbox_2016.asc | apt-key add - && \
+    echo "deb http://download.virtualbox.org/virtualbox/debian xenial contrib" >> /etc/apt/sources.list.d/virtualbox.list && \
+    apt-get update && apt-get install -y --no-install-recommends virtualbox-5.2 module-init-tools python3 python3-pip python3-setuptools wget unzip bash git && \
     wget https://releases.hashicorp.com/packer/1.3.1/packer_1.3.1_linux_amd64.zip && unzip packer_1.3.1_linux_amd64.zip -d packer && \
     mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.3.1_linux_amd64.zip && rmdir packer
 

--- a/tests/smoke/Dockerfile
+++ b/tests/smoke/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
     curl -sSL https://www.virtualbox.org/download/oracle_vbox_2016.asc | apt-key add - && \
     echo "deb http://download.virtualbox.org/virtualbox/debian xenial contrib" >> /etc/apt/sources.list.d/virtualbox.list && \
     apt-get update && apt-get install -y --no-install-recommends virtualbox-5.2 module-init-tools python3 python3-pip python3-setuptools wget unzip bash git && \
-    wget https://releases.hashicorp.com/packer/1.3.1/packer_1.3.1_linux_amd64.zip && unzip packer_1.3.1_linux_amd64.zip -d packer && \
-    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.3.1_linux_amd64.zip && rmdir packer
+    wget https://releases.hashicorp.com/packer/1.2.5/packer_1.2.5_linux_amd64.zip && unzip packer_1.2.5_linux_amd64.zip -d packer && \
+    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.2.5_linux_amd64.zip && rmdir packer
 
 # Config between delimiters taken from https://github.com/jenkinsci/docker/blob/master/Dockerfile
 # --

--- a/tests/smoke/Dockerfile
+++ b/tests/smoke/Dockerfile
@@ -4,8 +4,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
     curl -sSL https://www.virtualbox.org/download/oracle_vbox_2016.asc | apt-key add - && \
     echo "deb http://download.virtualbox.org/virtualbox/debian xenial contrib" >> /etc/apt/sources.list.d/virtualbox.list && \
     apt-get update && apt-get install -y --no-install-recommends virtualbox-5.2 module-init-tools python3 python3-pip python3-setuptools wget unzip bash git && \
-    wget https://releases.hashicorp.com/packer/1.2.5/packer_1.2.5_linux_amd64.zip && unzip packer_1.2.5_linux_amd64.zip -d packer && \
-    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.2.5_linux_amd64.zip && rmdir packer
+    wget https://releases.hashicorp.com/packer/1.0.3/packer_1.0.3_linux_amd64.zip && unzip packer_1.0.3_linux_amd64.zip -d packer && \
+    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.0.3_linux_amd64.zip && rmdir packer
+
 
 # Config between delimiters taken from https://github.com/jenkinsci/docker/blob/master/Dockerfile
 # --

--- a/tests/smoke/Dockerfile
+++ b/tests/smoke/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
     curl -sSL https://www.virtualbox.org/download/oracle_vbox_2016.asc | apt-key add - && \
     echo "deb http://download.virtualbox.org/virtualbox/debian xenial contrib" >> /etc/apt/sources.list.d/virtualbox.list && \
     apt-get update && apt-get install -y --no-install-recommends virtualbox-5.2 module-init-tools python3 python3-pip python3-setuptools wget unzip bash git && \
-    wget https://releases.hashicorp.com/packer/1.0.3/packer_1.0.3_linux_amd64.zip && unzip packer_1.0.3_linux_amd64.zip -d packer && \
-    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.0.3_linux_amd64.zip && rmdir packer
+    wget https://releases.hashicorp.com/packer/1.3.1/packer_1.3.1_linux_amd64.zip && unzip packer_1.3.1_linux_amd64.zip -d packer && \
+    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.3.1_linux_amd64.zip && rmdir packer
 
 
 # Enable this RUN statement when you need to connect to the VRDP server of the VM to troubleshoot issues

--- a/tests/smoke/Dockerfile
+++ b/tests/smoke/Dockerfile
@@ -5,11 +5,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
     echo "deb http://download.virtualbox.org/virtualbox/debian xenial contrib" >> /etc/apt/sources.list.d/virtualbox.list && \
     apt-get update && apt-get install -y --no-install-recommends virtualbox-5.2 module-init-tools python3 python3-pip python3-setuptools wget unzip bash git && \
     wget https://releases.hashicorp.com/packer/1.0.3/packer_1.0.3_linux_amd64.zip && unzip packer_1.0.3_linux_amd64.zip -d packer && \
-    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.0.3_linux_amd64.zip && rmdir packer && \
-    VBOXVER=$(wget -qO - https://download.virtualbox.org/virtualbox/LATEST.TXT) && \
-    wget "https://download.virtualbox.org/virtualbox/${VBOXVER}/Oracle_VM_VirtualBox_Extension_Pack-${VBOXVER}.vbox-extpack" && \
-    VBoxManage extpack install --accept-license=56be48f923303c8cababb0bb4c478284b688ed23f16d775d729b89a2e8e5f9eb Oracle_VM_VirtualBox_Extension_Pack-${VBOXVER}.vbox-extpack && \
-    rm Oracle_VM_VirtualBox_Extension_Pack-${VBOXVER}.vbox-extpack
+    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.0.3_linux_amd64.zip && rmdir packer
+
+
+# Enable this RUN statement when you need to connect to the VRDP server of the VM to troubleshoot issues
+#RUN VBOXVER=$(wget -qO - https://download.virtualbox.org/virtualbox/LATEST.TXT) && \
+#    wget "https://download.virtualbox.org/virtualbox/${VBOXVER}/Oracle_VM_VirtualBox_Extension_Pack-${VBOXVER}.vbox-extpack" && \
+#    VBoxManage extpack install --accept-license=56be48f923303c8cababb0bb4c478284b688ed23f16d775d729b89a2e8e5f9eb Oracle_VM_VirtualBox_Extension_Pack-${VBOXVER}.vbox-extpack && \
+#    rm Oracle_VM_VirtualBox_Extension_Pack-${VBOXVER}.vbox-extpack
 
 
 # Config between delimiters taken from https://github.com/jenkinsci/docker/blob/master/Dockerfile

--- a/tests/smoke/Dockerfile
+++ b/tests/smoke/Dockerfile
@@ -5,7 +5,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
     echo "deb http://download.virtualbox.org/virtualbox/debian xenial contrib" >> /etc/apt/sources.list.d/virtualbox.list && \
     apt-get update && apt-get install -y --no-install-recommends virtualbox-5.2 module-init-tools python3 python3-pip python3-setuptools wget unzip bash git && \
     wget https://releases.hashicorp.com/packer/1.0.3/packer_1.0.3_linux_amd64.zip && unzip packer_1.0.3_linux_amd64.zip -d packer && \
-    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.0.3_linux_amd64.zip && rmdir packer
+    mv packer/packer /usr/local/bin/ && chmod a+x /usr/local/bin/packer && rm packer_1.0.3_linux_amd64.zip && rmdir packer && \
+    VBOXVER=$(wget -qO - https://download.virtualbox.org/virtualbox/LATEST.TXT) && \
+    wget "https://download.virtualbox.org/virtualbox/${VBOXVER}/Oracle_VM_VirtualBox_Extension_Pack-${VBOXVER}.vbox-extpack" && \
+    VBoxManage extpack install --accept-license=56be48f923303c8cababb0bb4c478284b688ed23f16d775d729b89a2e8e5f9eb Oracle_VM_VirtualBox_Extension_Pack-${VBOXVER}.vbox-extpack && \
+    rm Oracle_VM_VirtualBox_Extension_Pack-${VBOXVER}.vbox-extpack
 
 
 # Config between delimiters taken from https://github.com/jenkinsci/docker/blob/master/Dockerfile

--- a/tests/smoke/config.js
+++ b/tests/smoke/config.js
@@ -41,8 +41,8 @@
     //"hypervisor": "kvm",
 
     // Chocolatey packages to install on the VM
-    // TODO re-add dependencywalker and regshot once upstream choco package provides a checksum
-    "choco_packages": "sysinternals windbg wireshark 7zip putty apm",
+    // FIXME made install go faster to prevent jenkins / packer bug when building Windows 7 machines (see #108)
+    //"choco_packages": "sysinternals windbg wireshark 7zip putty apm",
 
     // Setting the IDA Path will copy the IDA remote debugging tools into the guest
     //"ida_path": "/path/to/your/ida",

--- a/tests/smoke/config.js
+++ b/tests/smoke/config.js
@@ -25,7 +25,7 @@
     "password": "malboxes",
     "computername": "smoketest",
     // disk size is in megabytes
-    "disk_size": "20480",
+    "disk_size": "40960",
 
     // Windows Defender: true means enabled, false means disabled. Default is false.
     //"windows_defender": "false",


### PR DESCRIPTION
- Worked around the Windows 7 build problem, I think it has to do with duration of the build so I streamlined it by removing chocolatey package from smoke tests. Long term goal is to use vagrant for provisioning anyway.
- Building using latest VirtualBox directly from upstream
- New `Clean` step that removes the large vagrant box files on successful builds (was generating a lot of stress for our backups)

Such a small diff for the last 19 days I spend trying to get Windows 7 builds to work...