### PR TITLE
AWS support for Malboxes

### DIFF
--- a/malboxes/config-example.js
+++ b/malboxes/config-example.js
@@ -49,6 +49,8 @@
 	"aws_access_key": "",
 	"aws_secret_key": "",
 	"aws_s3_bucket": "",
+	"aws_security_group": "",
+	"aws_keypair": "",
 
 	//"proxy": "company_proxy:3128",
 

--- a/malboxes/config-example.js
+++ b/malboxes/config-example.js
@@ -45,6 +45,10 @@
 	"vsphere_user": "",
 	"vsphere_password": "",
 	"vsphere_insecure": "true",
+	// If AWS,  the following configuration options are mandatory
+	"aws_access_key": "",
+	"aws_secret_key": "",
+	"aws_s3_bucket": "",
 
 	//"proxy": "company_proxy:3128",
 

--- a/malboxes/malboxes.py
+++ b/malboxes/malboxes.py
@@ -463,6 +463,16 @@ def spin(parser, args):
     elif config['hypervisor'] == 'vsphere':
         with open("Vagrantfile", 'w') as f:
             _prepare_vagrantfile(config, "analyst_vsphere.rb", f)
+    elif config['hypervisor'] == 'aws':
+        with open("Vagrantfile", 'w') as f:
+            manifest_filename = os.path.join(DIRS.user_cache_dir,
+                                             "manifest.json")
+            with open(manifest_filename, 'r') as _f:
+                _manifest = json.loads(_f.read())
+            # AMI Id is like: [builds][0][artifact_id] == "us-east-1:ami-aabbccddeeff0011"
+            # and we keep after the colon
+            config['aws_ami_id'] = _manifest['builds'][0]['artifact_id'].split(':')[1]
+            _prepare_vagrantfile(config, "analyst_aws.rb", f)
     print("Vagrantfile generated. You can move it in your analysis directory "
           "and issue a `vagrant up` to get started with your VM.")
 

--- a/malboxes/templates/snippets/builder_virtualbox_windows.json
+++ b/malboxes/templates/snippets/builder_virtualbox_windows.json
@@ -13,4 +13,7 @@
 		],
 		"boot_wait": "10s",
 		"disk_size": "{{ disk_size }}",
+	{% if hypervisor == "aws" %}
+		"format": "ova",
+	{% endif %}
 		"output_directory": "builds"

--- a/malboxes/templates/snippets/postprocessor_aws.json
+++ b/malboxes/templates/snippets/postprocessor_aws.json
@@ -1,0 +1,17 @@
+"post-processors": [
+    {# List of list used to make sure post-processors are not run in parallel #}
+    [{
+        "type": "amazon-import",
+        "access_key": "{{ aws_access_key }}",
+        "secret_key": "{{ aws_secret_key }}",
+        "region": "us-east-1",
+        "ami_name": "malboxes",
+        "s3_bucket_name": "{{ aws_s3_bucket }}", 
+        "license_type": "BYOL",
+        "tags": { "Description": "packer amazon import" } 
+    },
+    {
+      "type": "manifest",
+      "output": "{{ cache_dir }}/manifest.json"
+    }]
+]

--- a/malboxes/templates/snippets/postprocessor_aws.json
+++ b/malboxes/templates/snippets/postprocessor_aws.json
@@ -6,9 +6,9 @@
         "secret_key": "{{ aws_secret_key }}",
         "region": "us-east-1",
         "ami_name": "malboxes",
-        "s3_bucket_name": "{{ aws_s3_bucket }}", 
+        "s3_bucket_name": "{{ aws_s3_bucket }}",
         "license_type": "BYOL",
-        "tags": { "Description": "packer amazon import" } 
+        "tags": { "Description": "packer amazon import" }
     },
     {
       "type": "manifest",

--- a/malboxes/templates/win10_64_analyst.json
+++ b/malboxes/templates/win10_64_analyst.json
@@ -1,7 +1,7 @@
 {
 	"builders": [{
 
-		{% if hypervisor == "virtualbox" %}
+		{% if hypervisor == "virtualbox" or hypervisor == "aws" %}
 			"guest_os_type": "Windows10_64",
 			{% include 'snippets/builder_virtualbox_windows.json' %},
 		{% elif hypervisor == "vsphere" %}
@@ -24,6 +24,8 @@
 
 	{% if hypervisor == 'virtualbox' %}
 		{% include 'snippets/postprocessor_vagrant.json' %},
+	{% elif hypervisor == 'aws' %}
+		{% include 'snippets/postprocessor_aws.json' %},
 	{% endif %}
 
 	"provisioners": [

--- a/malboxes/vagrantfiles/analyst_aws.rb
+++ b/malboxes/vagrantfiles/analyst_aws.rb
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure(2) do |config|
+    # Using dummy box with provider=aws metadata
+    config.vm.box = "dummy"
+    config.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
+
+    config.vm.guest = :windows
+    config.vm.communicator = :winrm
+    config.winrm.username = "{{ username }}"
+    config.winrm.password = "{{ password }}"
+
+    config.vm.provider :aws do |aws, override|
+        aws.access_key_id = "{{ aws_access_key }}"
+        aws.secret_access_key = "{{ aws_secret_key }}"
+        aws.instance_type = "m3.medium"
+        aws.security_groups = "{{ aws_security_group }}"
+        aws.keypair_name = "{{ aws_keypair }}"
+        # FIXME still experimenting with this one
+        aws.terminate_on_shutdown = true
+        aws.ami = "{{ aws_ami_id }}"
+    end
+end


### PR DESCRIPTION
This feature allows Malboxes to create instances of VM on the Amazon Elastic Compute Cloud (EC2)