### PR TITLE
Removed APM from default chocolatey packages

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == <next release>
 
+Bug fixes::
+  * Removed APM from default chocolatey packages ({uri-issue}119[#119])
+
 Infrastructure Improvements::
 * Further improvements to Jenkins CI system fixed Windows 7 build issues ({uri-issue}108[#108], {uri-issue}110[#110])
 

--- a/malboxes/config-example.js
+++ b/malboxes/config-example.js
@@ -56,7 +56,7 @@
 	// Chocolatey packages to install on the VM
 	// TODO re-add dependencywalker and regshot once upstream choco package provides a checksum
 	// TODO: Re-add processhacker when its fixed for win7_64
-	"choco_packages": "sysinternals windbg 7zip putty apm wireshark winpcap",
+	"choco_packages": "sysinternals windbg 7zip putty wireshark winpcap",
 
 	// Setting the IDA Path will copy the IDA remote debugging tools into the guest
 	//"ida_path": "/path/to/your/ida",

--- a/tests/smoke/config.js
+++ b/tests/smoke/config.js
@@ -42,7 +42,7 @@
 
     // Chocolatey packages to install on the VM
     // FIXME made install go faster to prevent jenkins / packer bug when building Windows 7 machines (see #108)
-    //"choco_packages": "sysinternals windbg wireshark 7zip putty apm",
+    //"choco_packages": "sysinternals windbg wireshark 7zip putty",
 
     // Setting the IDA Path will copy the IDA remote debugging tools into the guest
     //"ida_path": "/path/to/your/ida",


### PR DESCRIPTION
Malboxes doesn't build with the default configs, so I removed the package causing problem. It still exists on Chocolatey but has been flagged by VT.