### PR TITLE
CI: Install malboxes from local repository instead of upstream

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,7 @@ Bug fixes::
 
 Infrastructure Improvements::
 * Further improvements to Jenkins CI system fixed Windows 7 build issues ({uri-issue}108[#108], {uri-issue}110[#110])
+* Jenkins CI system can now perform smoke tests on external PRs ({uri-issue}123[#123])
 
 
 == 0.4.0

--- a/tests/smoke/build-all-templates.sh
+++ b/tests/smoke/build-all-templates.sh
@@ -16,7 +16,8 @@
 #
 
 export PATH=$PATH:$HOME/.local/bin
-#pip3 install --upgrade git+https://github.com/GoSecure/malboxes.git@${GIT_BRANCH#*/}#egg=malboxes
+
+echo "Performing a local install of malboxes in development mode"
 pip3 install -e .
 
 echo "Fetching all templates..."

--- a/tests/smoke/build-all-templates.sh
+++ b/tests/smoke/build-all-templates.sh
@@ -16,7 +16,8 @@
 #
 
 export PATH=$PATH:$HOME/.local/bin
-pip3 install --upgrade git+https://github.com/GoSecure/malboxes.git@${GIT_BRANCH#*/}#egg=malboxes
+#pip3 install --upgrade git+https://github.com/GoSecure/malboxes.git@${GIT_BRANCH#*/}#egg=malboxes
+pip3 install -e .
 
 echo "Fetching all templates..."
 TEMPLATES=`malboxes list | head -n-1 | tail -n+3`


### PR DESCRIPTION
Will enable building branches and PRs in Jenkins for smoke testing