### PR TITLE
CI: checking `malboxes list` return code

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,8 +13,7 @@ Bug fixes::
   * Disabled malware protection, cloud and automatic sample submission on Windows 10 ({uri-issue}120[#120])
 
 Infrastructure Improvements::
-* Further improvements to Jenkins CI system fixed Windows 7 build issues ({uri-issue}108[#108], {uri-issue}110[#110])
-* Jenkins CI system can now perform smoke tests on external PRs ({uri-issue}123[#123])
+* Various Jenkins CI system improvements ({uri-issue}108[#108], {uri-issue}110[#110], {uri-issue}123[#123], {uri-issue}124[#124])
 
 
 == 0.4.0

--- a/tests/smoke/build-all-templates.sh
+++ b/tests/smoke/build-all-templates.sh
@@ -22,6 +22,11 @@ pip3 install -e .
 
 echo "Fetching all templates..."
 TEMPLATES=`malboxes list | head -n-1 | tail -n+3`
+if [[ ${PIPESTATUS[0]} != 0 ]]; then
+        echo "Malboxes didn't list templates. This is a fatal error. Force failing the build."
+	exit 1
+fi
+
 
 # build all templates
 declare -A RESULTS


### PR DESCRIPTION
Otherwise python or other low-level errors don't get logged in Jenkins