### PR TITLE
Using VirtualBox's linked clones by default

### DIFF
--- a/malboxes/vagrantfiles/box_win.rb
+++ b/malboxes/vagrantfiles/box_win.rb
@@ -11,5 +11,6 @@ Vagrant.configure(2) do |config|
 		vb.gui = true
 		vb.customize ["modifyvm", :id, "--vram", "128"]
 		vb.customize ["modifyvm", :id, "--draganddrop", "hosttoguest"]
+		vb.linked_clone = true
 	end
 end


### PR DESCRIPTION
It saves disk space when the base machine is re-used across multiple spins.