### PR TITLE
Enabled User Account Control (UAC). Fixes #93.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == <next release>
 
+Enhancements::
+* Enabling UAC so the default account can use Edge without requiring changes ({uri-issue}93[#93])
+
 Bug fixes::
   * Removed APM from default chocolatey packages ({uri-issue}119[#119])
   * Disabled malware protection, cloud and automatic sample submission on Windows 10 ({uri-issue}120[#120])

--- a/malboxes/scripts/windows/uac.ps1
+++ b/malboxes/scripts/windows/uac.ps1
@@ -1,0 +1,6 @@
+# Set UAC to default level (so Edge can be used from account)
+# Note: a restart is required
+$Path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
+Set-ItemProperty -Path $Path -Name ConsentPromptBehaviorAdmin -Value 5 -Type "Dword"
+Set-ItemProperty -Path $Path -Name PromptOnSecureDesktop -Value 1 -Type "Dword"
+Set-ItemProperty -Path $Path -Name EnableLUA -Value 1 -Type "Dword"

--- a/malboxes/templates/snippets/provision_powershell.json
+++ b/malboxes/templates/snippets/provision_powershell.json
@@ -8,6 +8,7 @@
 			{% endif %}
 			"{{ dir }}/scripts/windows/installtools.ps1",
 			{% if profile is defined %}"{{ cache_dir }}/profile-{{ profile }}.ps1",{% endif %}
+			"{{ dir }}/scripts/windows/uac.ps1",
 			"{{ dir }}/scripts/windows/malware_analysis.ps1"
 		]
 	}


### PR DESCRIPTION
Fixes issues where Edge can't be opened by our default account without
changes that requires a reboot or creating a low priv user. Pretty annoying.