### PR TITLE
Added pacman command line for ArchLinux requirements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,10 @@ https://github.com/gosecure/malboxes
 
     apt install vagrant git python3-pip
 
+=== ArchLinux
+
+    pacman -Sy vagrant packer python-pip git
+
 == Installation
 
 === Linux/Unix


### PR DESCRIPTION
The readme currently only specifies the packages for Fedora and Debian. Adding ArchLinux.

The packer-io package was renamed to packer: https://www.archlinux.org/packages/community/x86_64/packer/