### PR TITLE
Ubuntu requirements and detailed vagrant install

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -53,13 +53,18 @@ https://github.com/gosecure/malboxes
 === Debian
 
     apt install vagrant git python3-pip
+    
+=== Ubuntu
+
+    apt install git python3-pip
 
 == Installation
 
 === Linux/Unix
 
-* Install git, vagrant and packer using your distribution's packaging tool
+* Install git and packer using your distribution's packaging tool
   (packer is sometimes called packer-io)
+* Install vagrant from their website : https://www.vagrantup.com/downloads.html (Installing from some distributions' packaging tools have caused issues). 
 * `pip install` malboxes:
 +
     sudo pip3 install git+https://github.com/GoSecure/malboxes.git#egg=malboxes


### PR DESCRIPTION
I added install notes for Ubuntu, specifically so that people do not install vagrant using the package manager. It causes issues when running malboxes.