### PR TITLE
Adding Python 3.7 and 3.8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 install: pip install -r requirements.txt && pip install pylint
 sudo: false
 script: make test


### PR DESCRIPTION
Python 3.7 has been released in June 2018 and it is expected that security updates until approximately June 2023.

Python 3.8 has been released in October 2019 and it is expected that security updates until approximately October 2024.

See [PEP 537 -- Python 3.7 Release Schedule](https://www.python.org/dev/peps/pep-0537/) and [PEP 569 -- Python 3.8 Release Schedule ](https://www.python.org/dev/peps/pep-0569/).