### PR TITLE
remove iso_checksum_type in win10 and win7 templates. Fix for #141

### DIFF
--- a/malboxes/templates/snippets/win10_x64_analyst.json
+++ b/malboxes/templates/snippets/win10_x64_analyst.json
@@ -14,7 +14,6 @@
 			"{{ iso_url }}"
 		],
 		"iso_checksum": "{{ iso_checksum }}",
-		"iso_checksum_type": "sha1",
 
 		"floppy_files": [
 			"{{ cache_dir }}/Autounattend.xml",

--- a/malboxes/templates/snippets/win10_x86_analyst.json
+++ b/malboxes/templates/snippets/win10_x86_analyst.json
@@ -14,7 +14,6 @@
 			"{{ iso_url }}"
 		],
 		"iso_checksum": "{{ iso_checksum }}",
-		"iso_checksum_type": "sha1",
 
 		"floppy_files": [
 			"{{ cache_dir }}/Autounattend.xml",

--- a/malboxes/templates/win7_x64_analyst.json
+++ b/malboxes/templates/win7_x64_analyst.json
@@ -6,14 +6,12 @@
 		{% if trial != 'true' %}
 			"iso_url": "file://{{ iso_path }}/en_windows_7_professional_with_sp1_x64_dvd_u_676939.iso",
 			"iso_checksum": "0bcfc54019ea175b1ee51f6d2b207a3d14dd2b58",
-			"iso_checksum_type": "sha1",
 		{% else %}
 			"iso_urls": [
 				"file://{{ iso_path }}/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
                                 "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso"
 			],
 			"iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
-			"iso_checksum_type": "sha1",
 		{% endif %}
 
 		"floppy_files": [

--- a/malboxes/templates/win7_x86_analyst.json
+++ b/malboxes/templates/win7_x86_analyst.json
@@ -6,14 +6,12 @@
 		{% if trial != 'true' %}
 			"iso_url": "file://{{ iso_path }}/en_windows_7_professional_with_sp1_x86_dvd_u_677056.iso",
 			"iso_checksum": "d89937df3a9bc2ec1a1486195fd308cd3dade928",
-			"iso_checksum_type": "sha1",
 		{% else %}
 			"iso_urls": [
 				"file://{{ iso_path }}/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
 				"http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso"
 			],
 			"iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
-			"iso_checksum_type": "sha1",
 		{% endif %}
 
 		"floppy_files": [


### PR DESCRIPTION
Packer removed the field iso_checksum_type in https://github.com/hashicorp/packer/commit/0fa60c68fbfcf5ef29485489a41f5afa0565bdee